### PR TITLE
fixed typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The function `readCode(path)` takes a one argument and returns a promise with a 
 ```js
 import { readCode } from "camp2-helpers";
 
-const code = await readCode("path/of/your/file"));
+const code = await readCode("path/of/your/file");
 ```
 
 It can be used for testing with `jest` the following way.
@@ -99,7 +99,7 @@ const hello = "Hello World!";
 
 ```js
 // index.test.js
-const readcode = require("./readcode");
+const readcode = require("camp2-helpers");
 
 let code;
 beforeAll(() => {


### PR DESCRIPTION
## Description

### Current problem : 

#### 2 typos in readme

- too much parenthesis line 90
- import wrong package line 102

### What I've done : 

- remove parenthesis
- import camp2-helpers

## Types of changes

- [x] Chore (non-breaking change which refactors / improves the existing code base)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to 
  change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**][CONTRIBUTING_FILE] document.

[CONTRIBUTING_FILE]: https://github.com/fewlinesco/connect/blob/master/CONTRIBUTING.md
