### PR TITLE
added the missing types

### DIFF
--- a/astNodeParser/astNodeParser.types.ts
+++ b/astNodeParser/astNodeParser.types.ts
@@ -34,4 +34,8 @@ export interface Node extends namedTypes.Node {
   async: boolean;
   params: Node[];
   value: Node;
+  superClass: Node;
+  returnType: {
+    typeAnnotation: Node;
+  } & Node;
 }


### PR DESCRIPTION
# Currently

## Now we have a Node type that misses returnType  and typeAnnotation that is part of the return type. 

```typescript
export interface Node extends namedTypes.Node {
  id: Node;
  name: string;
  body: Node[] & { body: Node[] };
  declarations: Node[];
  declaration: Node;
  key: Node;
  abstract: boolean;
  static: boolean;
  readonly: boolean;
  kind: NODE_KIND;
  accessibility: ACCESSIBILITY;
  async: boolean;
  params: Node[];
  value: Node;
}
```

# What I'm doing

## Adding the missing types : 

```typescript
export interface Node extends namedTypes.Node {
  id: Node;
  name: string;
  body: Node[] & { body: Node[] };
  declarations: Node[];
  declaration: Node;
  key: Node;
  abstract: boolean;
  static: boolean;
  readonly: boolean;
  kind: NODE_KIND;
  accessibility: ACCESSIBILITY;
  async: boolean;
  params: Node[];
  value: Node;
  superClass: Node;
  returnType: {
    typeAnnotation: Node;
  } & Node;
}
```